### PR TITLE
 adjusting app name in center by removing align center

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+TwoMetics

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,7 @@
       <map>
         <entry key="..\:/Users/DESKTOP/AndroidStudioProjects/TwoMetics/app/src/main/res/layout/activity_main.xml" value="0.25" />
         <entry key="..\:/Users/DESKTOP/AndroidStudioProjects/TwoMetics/app/src/main/res/layout/activity_splash_ui.xml" value="0.18" />
+        <entry key="app/src/main/res/layout/activity_main.xml" value="0.14583333333333334" />
       </map>
     </option>
   </component>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,10 +28,9 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_marginStart="50dp"
+                android:layout_marginStart="60dp"
                 android:text="@string/app_name"
-                android:textSize="24sp"
-                android:textAlignment="center"/>
+                android:textSize="24sp" />
 
         </LinearLayout>
 


### PR DESCRIPTION
t seems that the app name in the appbar goes to the left too much .
I have arranged by making few edit ,
Please review the pull request and merge it.